### PR TITLE
upgrade to boot 2.0.0-RC1

### DIFF
--- a/recipes/boot-setup/README.md
+++ b/recipes/boot-setup/README.md
@@ -15,7 +15,7 @@ Another example project on boot-cljs: [boot-cljs-example].
 boot -u
 ```
 
-This will update boot to the latest stable release version. Since boot is
+This will update boot to the latest stable release version (tested with 2.0.0-RC1). Since boot is
 pre-alpha software at the moment, you should do this frequently.
 
 ## Use

--- a/recipes/boot-setup/build.boot
+++ b/recipes/boot-setup/build.boot
@@ -3,16 +3,16 @@
 (set-env!
   :src-paths #{"src"}
   :rsc-paths #{"html"}
-  :dependencies '[[adzerk/boot-cljs "0.0-2371-27" :scope "test"]
-                  [adzerk/boot-cljs-repl "0.1.6" :scope "test"]
-                  [adzerk/boot-reload "0.1.7" :scope "test"]
+  :dependencies '[[adzerk/boot-cljs "0.0-2411-3" :scope "test"]
+                  [adzerk/boot-cljs-repl "0.1.7" :scope "test"]
+                  [adzerk/boot-reload "0.2.0" :scope "test"]
                   [org.clojure/clojure "1.7.0-alpha4"]
                   [org.clojure/clojurescript "0.0-2371"]
                   [om "0.8.0-beta1"]])
 
 (task-options!
-  pom [:project 'boot-setup
-       :version "0.1.0-SNAPSHOT"])
+  pom {:project 'boot-setup
+       :version "0.1.0-SNAPSHOT"})
 
 (require '[adzerk.boot-cljs :refer :all]
  '[adzerk.boot-cljs-repl :refer :all]


### PR DESCRIPTION
Running boot-setup recipes on boot 2.0.0-RC1 ended with strange errors. Bump to latest version.
