### PR TITLE
Sorting doesn't modify the app state anymore, table component now self-contained

### DIFF
--- a/recipes/sortable-table/src/clj/sortable_table/server.clj
+++ b/recipes/sortable-table/src/clj/sortable_table/server.clj
@@ -26,7 +26,7 @@
   (defonce ^:private server
     (do
       (if is-dev? (start-figwheel))
-      (let [port (Integer. (or port (env :port) 10555))]
+      (let [port (Integer. (or port (env :port) 10559))]
         (print "Starting web server on port" port ".\n")
         (run-server http-handler {:port port
                           :join? false}))))


### PR DESCRIPTION
I've updated the code to not modify the data in the app state when sorting. Instead the sort direction and key are being stored as component local state and the data is being sorted on the fly when the user changes the state. This makes the component more flexible. Also, changed it so that the component only needs one cursor and no further derefs into the app state are required, to help reusability. 

I could have used core.async for the event handling, but wanted to keep it simple, so now the table defines a function that it hands into the header. The header then calls this function when the user clicks an arrow, and the function will change the table local component state, causing a rer-ender.