### PR TITLE
Amend boot-setup docs to help with missing target

### DIFF
--- a/recipes/boot-setup/README.md
+++ b/recipes/boot-setup/README.md
@@ -18,6 +18,13 @@ boot -u
 This will update boot to the latest stable release version (tested with 2.0.0-RC1). Since boot is
 pre-alpha software at the moment, you should do this frequently.
 
+```bash
+boot cljs
+```
+
+This ensures that the target directory `target/` directory (from which the
+project is served) exists.
+
 ## Use
 
 ```bash


### PR DESCRIPTION
A fresh clone of `om-cookbook` repo is missing the target directory `om-cookbook/recipes/boot-setup/target` which makes `boot dev` fail. Instruct the user to take an extra preparatory step that establishes the directory in case it is missing.