### PR TITLE
 Update build.boot in boot-setup

### DIFF
--- a/recipes/boot-setup/build.boot
+++ b/recipes/boot-setup/build.boot
@@ -16,7 +16,7 @@
        :version "0.1.0-SNAPSHOT"})
 
 (require '[adzerk.boot-cljs :refer [cljs]]
-         '[adzerk.boot-cljs-repl :refer [cljs-repl]]
+         '[adzerk.boot-cljs-repl :refer [cljs-repl start-repl]]
          '[adzerk.boot-reload :refer [reload]]
          '[pandeiro.boot-http :refer [serve]])
 


### PR DESCRIPTION
Added start-repl to :refer attribute of adzerk.boot-cljs-repl entry in require form of build.boot so client browser repl can start as per  README.md.
